### PR TITLE
DE144515 fix: ignore nulls and undefined values while calculating extents.

### DIFF
--- a/px-vis-behavior-scale-multi-axis.html
+++ b/px-vis-behavior-scale-multi-axis.html
@@ -120,7 +120,8 @@ PxVisBehaviorScale.scaleMultiAxis = [{
             checkForMute = this.hardMute && !!mutedCatKeys.length,
             arrayAccessor = function(d) {
               //ignore muted categories for extents
-              if(checkForMute && mutedCatKeys.indexOf(d[this.categoryKey]) !== -1) {
+              // ignore null or undefined values in extents calculation: DE144515 fix
+              if((checkForMute && mutedCatKeys.indexOf(d[this.categoryKey]) !== -1) || !d[dim]) {
                 return;
               }
               return Number(d[dim]);


### PR DESCRIPTION
DE144515 fix: ignore nulls and undefined values while calculating extents.

# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:

* ## A reference to a related issue (if applicable):

* ## @mentions of the person or team responsible for reviewing proposed changes:

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
