### PR TITLE
US567388: Parallel axis : fix color for 3 ranges when CBF is applied

### DIFF
--- a/px-vis-behavior-common.html
+++ b/px-vis-behavior-common.html
@@ -3591,11 +3591,32 @@ PxVisBehavior.gradientColorsFunction = {
         }.bind(this);
       } else if(typeof colors === 'function') {
         return function(val) {
-          return colors(this._normalizeValue(val), _parxColorValue);
+          if(_parxColorValue && _parxColorValue.gradientColorsRange){
+            return colors(this._normalizeValueWithTS(val, _parxColorValue), _parxColorValue);
+          } else {
+            return colors(this._normalizeValue(val), _parxColorValue);
+          }
         }.bind(this);
       } else {
         console.warn('Color gradient ' + colors + ' has an invalid type. Should be string, array or function');
       }
+    }
+  },
+
+  /**
+   * Use provided timestamps to calculative relative val
+   * */
+  _normalizeValueWithTS: function(val, _parxColorValue) {
+    if(_parxColorValue.gradientColorsRange.length === 2 && (_parxColorValue.gradientColorsRange[0] !==  undefined && _parxColorValue.gradientColorsRange[0] !== '') && (_parxColorValue.gradientColorsRange[1] !== undefined && _parxColorValue.gradientColorsRange[1] !== '')) {
+      let minTS = _parxColorValue.gradientColorsRange[0];
+      let maxTS = _parxColorValue.gradientColorsRange[1];
+      if(minTS === maxTS) {
+        return 0;
+      } else {
+        return (val - minTS) / (maxTS - minTS);
+      }
+    } else {
+      return this._normalizeValue(val);
     }
   },
 


### PR DESCRIPTION
# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request: US567388: Parallel axis : fix color for 3 ranges when CBF is applied
* Start and End timestamps will be passed to calculate relative val. This will fix the issue with the 3 color ranges going off when CBF is applied

* ## A reference to a related issue (if applicable): US567388

* ## @mentions of the person or team responsible for reviewing proposed changes:

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
