### PR TITLE
DE198157: Upon hovering on a tag in the tag browser not getting tag details

### DIFF
--- a/px-vis-register-item.html
+++ b/px-vis-register-item.html
@@ -75,7 +75,7 @@ Custom property | Description
             name$="R[[seriesKey]]">&nbsp;</span>
         </span>
         <span class$="[[_wrapperClass]]" style="width:100%;">
-          <div id="seriesName" class="seriesName flex__item--msfix" name$="R[[seriesKey]]" hidden$="[[isEbqChart]]">
+          <div id="seriesName" class="seriesName flex__item--msfix" name$="R[[seriesKey]]" hidden$="[[isEbqChart]]" on-mouseover="_onTitleHover" on-mouseout="_onTitleLeave">
             [[_truncatedName]]&nbsp;
           </div>
           <div id="seriesName" class="seriesName flex__item--msfix" name$="R[[seriesKey]]" hidden$="[[!isEbqChart]]">


### PR DESCRIPTION
# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:
DE198157: Upon hovering on a tag in the tag browser not getting tag details

* ## A reference to a related issue (if applicable): DE198157

* ## @mentions of the person or team responsible for reviewing proposed changes:

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
