### PR TITLE
473586 : Added category for the analysis v2 parallel axis charts

### DIFF
--- a/px-vis-behavior-data-converter.html
+++ b/px-vis-behavior-data-converter.html
@@ -142,6 +142,10 @@ PxVisBehavior.dataConverterMethods = {
             lowest = originalData[i][dataKey][indexes[i]][0];
             // set our obj x value
             obj[this.newXKey] = lowest;
+            // set category for spiderWeb and parallel.
+            if (originalData[i].category) {
+              obj.category = originalData[i].category;
+            }
             // set our obj y value
             obj[id[i]] = originalData[i][dataKey][indexes[i]][1];
             // track in index we are at


### PR DESCRIPTION
Added category for the analysis v2 parallel axis charts

# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:
* The data conveter does not include category key from originaldata into chartData  conversion which is required for the parallel axis charts in event data analysis

* ## A reference to a related issue (if applicable):

* ## @mentions of the person or team responsible for reviewing proposed changes:

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
