### PR TITLE
Fix for console error observed when crosshair is applied before chart is initialized

### DIFF
--- a/px-vis-behavior-common.html
+++ b/px-vis-behavior-common.html
@@ -2652,13 +2652,17 @@ PxVisBehavior.highlightShared = [{
    */
   _calcDataset: function() {
     var d = [],
-        lowerFuzz,
-        upperFuzz;
+      lowerFuzz,
+      upperFuzz,
+      hasChartData = Array.isArray(this.chartData) && this.chartData.length > 0;
 
-    for(var i = 0; i < this.crosshairData.timeStamps.length; i++) {
-
-      if(!this.hardMute || !this.mutedSeries[this.crosshairData.timeStamps[i]]) {
-        if(this.fuzz) {
+    if (!hasChartData || !this.crosshairData || !Array.isArray(this.crosshairData.timeStamps)) {
+      return d;
+    }
+    
+    for (var i = 0; i < this.crosshairData.timeStamps.length; i++) {
+      if (hasChartData && (!this.hardMute || !this.mutedSeries[this.crosshairData.timeStamps[i]])) {
+        if (this.fuzz) {
           lowerFuzz = this.crosshairData.timeStamps[i] - Number(this.fuzz);
           upperFuzz = this.crosshairData.timeStamps[i] + Number(this.fuzz);
 


### PR DESCRIPTION
Fix for below issue : Console error when crosshair is applied before chart is initialized

ERROR TypeError: Cannot read properties of undefined (reading 'x')
    at i._binarySearch (polymer-bundle.html-9.js:1:5164)
    at i._calcDataset (polymer-bundle.html-9.js:1:14052)
    at i.<anonymous> (polymer-bundle.html-98.js:1:1012)


# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:

* ## A reference to a related issue (if applicable):

* ## @mentions of the person or team responsible for reviewing proposed changes:

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
